### PR TITLE
Add Proxmox VE 9 support to molecule testing matrix

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -39,6 +39,7 @@ jobs:
         distro:
           - proxmox7
           - proxmox8
+          - proxmox9
 
     steps:
       - name: Check out the codebase.


### PR DESCRIPTION
- Added proxmox9 to GitHub Actions workflow matrix for automated testing
- Enables testing of Ansible roles against Proxmox VE 9 environments
- Uses the new spikebyte/docker-proxmox9-ansible image from docker-proxmox-ansible repository
- Maintains compatibility with existing PVE-7 and PVE-8 testing environments

This completes the integration between docker-proxmox-ansible and proxmox-config repositories for comprehensive multi-version Proxmox VE testing.